### PR TITLE
XSS (CWE 79) - Scala - The detector can be fooled when the .as("text/html") is in uppercase

### DIFF
--- a/scala-web-play/app/controllers/XssController.scala
+++ b/scala-web-play/app/controllers/XssController.scala
@@ -9,11 +9,16 @@ class XssController extends Controller {
     Ok("Hello "+value+" !").as("text/html")
   }
 
-  def vulnerable2(value:String, contentType:String) = Action {
+  def vulnerable2(value:String) = Action {
+    // This should be detected even if some characters are uppercase
+    Ok("Hello "+value+" !").as("tExT/HtML")
+  }
+
+  def vulnerable3(value:String, contentType:String) = Action {
     Ok("Hello "+value+" !").as(contentType)
   }
 
-  def vulnerable3(value:String) = Action {
+  def vulnerable4(value:String) = Action {
     Ok(views.html.xssHtml.render(Html.apply("Hello "+value+" !")))
   }
 
@@ -26,5 +31,13 @@ class XssController extends Controller {
     Ok(s"Hello $value !").as("text/json")
     Ok("<b>Hello !</b>").as("text/html")
     Ok(views.html.xssHtml.render(Html.apply("<b>Hello !</b>")))
+
+    val escapedValue = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(value);
+    Ok("Hello " + escapedValue + " !");
+    Ok("Hello " + escapedValue + " !").as("text/html");
+
+    val owaspEscapedValue = org.owasp.encoder.Encode.forHtml(value);
+    Ok("Hello " + owaspEscapedValue + " !");
+    Ok("Hello " + owaspEscapedValue + " !").as("text/html");
   }
 }

--- a/scala-web-play/build.sbt
+++ b/scala-web-play/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-slick-evolutions" % "1.1.0",
   "com.h2database" % "h2" % "1.4.177",
   "org.spire-math" %% "spire" % "0.11.0",
+  "org.owasp.encoder" % "encoder" % "1.2",
   specs2 % Test
 )     
 

--- a/scala-web-play/conf/routes
+++ b/scala-web-play/conf/routes
@@ -17,8 +17,9 @@ GET     /cmd/vulnerable6            controllers.CommandController.vulnerable6(va
 GET     /cmd/safe1                  controllers.CommandController.safe1()
 
 GET     /xss/vulnerable1            controllers.XssController.vulnerable1(value:String)
-GET     /xss/vulnerable2            controllers.XssController.vulnerable2(value:String, contentType:String)
-GET     /xss/vulnerable3            controllers.XssController.vulnerable3(value:String)
+GET     /xss/vulnerable2            controllers.XssController.vulnerable2(value:String)
+GET     /xss/vulnerable3            controllers.XssController.vulnerable3(value:String, contentType:String)
+GET     /xss/vulnerable4            controllers.XssController.vulnerable4(value:String)
 GET     /xss/potentiallyVulnerable  controllers.XssController.potentiallyVulnerable(value:String)
 GET     /xss/variousSafe            controllers.XssController.variousSafe(value:String)
 


### PR DESCRIPTION
While fixing the "solution" part of the SCALA_XSS_MVC_API message in message.xml (find-sec-bugs #203), I realized that there was no test case with encoded values and that .as("TEXT/HTML") was not properly detected.

I added those two test cases.
