### PR TITLE
Server Side Request Forgery (CWE 918) - Added basic test cases

### DIFF
--- a/scala-web-play/app/controllers/SSRFController.scala
+++ b/scala-web-play/app/controllers/SSRFController.scala
@@ -1,0 +1,53 @@
+package controllers
+
+import play.api.libs.ws._
+import play.api.mvc.{Action, Controller}
+
+import play.api.Play.current
+import play.api.libs.concurrent.Execution.Implicits._
+
+/**
+  * This controller is used to test detection of potential SSRF.
+  *
+  * See CWE-918 :
+  *     https://cwe.mitre.org/data/definitions/918.html
+  */
+class SSRFController extends Controller {
+
+  def vulnerableGet(value:String) = Action.async {
+
+    // This method could expose internal services like mongodb to an attacker
+    WS.url(value).get().map { response =>
+      Ok(response.body)
+    }
+  }
+
+  def vulnerablePost(value:String, postValue:String) = Action.async {
+
+    // These method could expose internal services like mongodb to an attacker
+    WS.url(value).post(postValue).map { response =>
+      Ok(response.body)
+    }
+
+    WS.url(value).post("key=value").map { response =>
+      Ok(response.body)
+    }
+
+    // This call could be used to attack another host from our server
+    WS.url("http://google.com").post(postValue).map { response =>
+      Ok(response.body)
+    }
+  }
+
+  def safeGetNotTainted() = Action.async {
+    WS.url("http://google.com").get().map { response =>
+      Ok(response.body)
+    }
+  }
+
+  def safePostNotTainted() = Action.async {
+    WS.url("http://google.com").post("key=value").map { response =>
+      Ok(response.body)
+    }
+  }
+}

--- a/scala-web-play/build.sbt
+++ b/scala-web-play/build.sbt
@@ -14,7 +14,8 @@ libraryDependencies ++= Seq(
   "com.h2database" % "h2" % "1.4.177",
   "org.spire-math" %% "spire" % "0.11.0",
   "commons-io" % "commons-io" % "2.5",
-  specs2 % Test
+  specs2 % Test,
+  ws
 )     
 
 // Play provides two styles of routers, one expects its actions to be injected, the

--- a/scala-web-play/conf/routes
+++ b/scala-web-play/conf/routes
@@ -47,5 +47,10 @@ GET     /path/vulnerableOut         controllers.PathTraversalController.vulnerab
 GET     /path/safeIn                controllers.PathTraversalController.safeIn(value:String)
 GET     /path/safeOut               controllers.PathTraversalController.safeOut(value:String)
 
+GET     /ssrf/vulnerableGet         controllers.SSRFController.vulnerableGet(value:String)
+GET     /ssrf/vulnerablePost        controllers.SSRFController.vulnerablePost(value:String, postValue:String)
+GET     /ssrf/safeGetNotTainted     controllers.SSRFController.safeGetNotTainted()
+GET     /ssrf/safePostNotTainted    controllers.SSRFController.safePostNotTainted()
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
Really basic test case to implement a SSRF detector.

It takes a URL and uses the web server to make a request to this URL. This could be used by an attacker to bypass firewalls by making requests to internal services like mongodb.
