### PR TITLE
Added some code samples for Play 2.5.x SSRF Detection

### DIFF
--- a/scala-web-play/app/controllers/SSRFController.scala
+++ b/scala-web-play/app/controllers/SSRFController.scala
@@ -72,20 +72,6 @@ class SSRFController @Inject() (wSClient: WSClient)  extends Controller {
     }
   }
 
-  def derp() = {
-    wSClient.url("http://www.google.com").get()
-
-    wSClient.url("http://www.google.com").get().map { response =>
-      Ok(response.body)
-    }
-
-    WS.url("http://www.google.com").get()
-
-    WS.url("http://www.google.com").get().map { response =>
-      Ok(response.body)
-    }
-  }
-
   def safeGetNotTainted() = Action.async {
     // ####################
     // Play v.2.5.x

--- a/scala-web-play/app/controllers/SSRFController.scala
+++ b/scala-web-play/app/controllers/SSRFController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import play.api.libs.ws._
 import play.api.mvc.{Action, Controller}
+import javax.inject._
 
 import play.api.Play.current
 import play.api.libs.concurrent.Execution.Implicits._
@@ -12,9 +13,21 @@ import play.api.libs.concurrent.Execution.Implicits._
   * See CWE-918 :
   *     https://cwe.mitre.org/data/definitions/918.html
   */
-class SSRFController extends Controller {
+class SSRFController @Inject() (wSClient: WSClient)  extends Controller {
 
   def vulnerableGet(value:String) = Action.async {
+
+    // ####################
+    // SBT 2.5.x
+    // ####################
+    // This method could expose internal services like mongodb to an attacker
+    wSClient.url(value).get().map { response =>
+      Ok(response.body)
+    }
+
+    // ####################
+    // SBT 2.4.x
+    // ####################
 
     // This method could expose internal services like mongodb to an attacker
     WS.url(value).get().map { response =>
@@ -24,6 +37,26 @@ class SSRFController extends Controller {
 
   def vulnerablePost(value:String, postValue:String) = Action.async {
 
+    // ####################
+    // SBT 2.5.x
+    // ####################
+    // These method could expose internal services like mongodb to an attacker
+    wSClient.url(value).post(postValue).map { response =>
+      Ok(response.body)
+    }
+
+    wSClient.url(value).post("key=value").map { response =>
+      Ok(response.body)
+    }
+
+    // This call could be used to attack another host from our server
+    wSClient.url("http://www.google.com").post(postValue).map { response =>
+      Ok(response.body)
+    }
+
+    // ####################
+    // SBT 2.4.x
+    // ####################
     // These method could expose internal services like mongodb to an attacker
     WS.url(value).post(postValue).map { response =>
       Ok(response.body)
@@ -39,7 +72,33 @@ class SSRFController extends Controller {
     }
   }
 
+  def derp() = {
+    wSClient.url("http://www.google.com").get()
+
+    wSClient.url("http://www.google.com").get().map { response =>
+      Ok(response.body)
+    }
+
+    WS.url("http://www.google.com").get()
+
+    WS.url("http://www.google.com").get().map { response =>
+      Ok(response.body)
+    }
+  }
+
   def safeGetNotTainted() = Action.async {
+    // ####################
+    // Play v.2.5.x
+    // ####################
+    wSClient.url("http://www.google.com").get()
+
+    wSClient.url("http://www.google.com").get().map { response =>
+      Ok(response.body)
+    }
+
+    // ####################
+    // Play v.2.4.x
+    // ####################
     WS.url("http://www.google.com").get()
 
     WS.url("http://www.google.com").get().map { response =>
@@ -48,6 +107,20 @@ class SSRFController extends Controller {
   }
 
   def safePostNotTainted() = Action.async {
+    // ####################
+    // Play v.2.5.x
+    // ####################
+    wSClient.url("http://www.google.com").post("key=value")
+
+    wSClient.url("http://www.google.com").post("key=value").map { response =>
+      Ok(response.body)
+    }
+
+    // ####################
+    // Play v.2.4.x
+    // ####################
+    WS.url("http://www.google.com").post("key=value")
+
     WS.url("http://www.google.com").post("key=value").map { response =>
       Ok(response.body)
     }
@@ -60,6 +133,18 @@ class SSRFController extends Controller {
       url = "http://mysite.com/transfer?amount=" + amount
     }
 
+    // ####################
+    // Play v.2.5.x
+    // ####################
+    wSClient.url("http://www.google.com").get()
+
+    wSClient.url("http://www.google.com").get().map { response =>
+      Ok(response.body)
+    }
+
+    // ####################
+    // Play v.2.4.x
+    // ####################
     WS.url(url).get()
 
     WS.url(url).get().map { response =>
@@ -74,6 +159,18 @@ class SSRFController extends Controller {
       url = "http://mysite.com/transfer"
     }
 
+    // ####################
+    // Play v.2.5.x
+    // ####################
+    wSClient.url(url).post("amount=" + amount)
+
+    wSClient.url(url).post("amount=" + amount).map { response =>
+      Ok(response.body)
+    }
+
+    // ####################
+    // Play v.2.4.x
+    // ####################
     WS.url(url).post("amount=" + amount)
 
     WS.url(url).post("amount=" + amount).map { response =>

--- a/scala-web-play/app/controllers/SSRFController.scala
+++ b/scala-web-play/app/controllers/SSRFController.scala
@@ -34,19 +34,49 @@ class SSRFController extends Controller {
     }
 
     // This call could be used to attack another host from our server
-    WS.url("http://google.com").post(postValue).map { response =>
+    WS.url("http://www.google.com").post(postValue).map { response =>
       Ok(response.body)
     }
   }
 
   def safeGetNotTainted() = Action.async {
-    WS.url("http://google.com").get().map { response =>
+    WS.url("http://www.google.com").get()
+
+    WS.url("http://www.google.com").get().map { response =>
       Ok(response.body)
     }
   }
 
   def safePostNotTainted() = Action.async {
-    WS.url("http://google.com").post("key=value").map { response =>
+    WS.url("http://www.google.com").post("key=value").map { response =>
+      Ok(response.body)
+    }
+  }
+
+  def safeGetWithWhitelist(value:String, amount:Int) = Action.async {
+    var url = "http://mysite.com/error"
+
+    if (value == "transfer") {
+      url = "http://mysite.com/transfer?amount=" + amount
+    }
+
+    WS.url(url).get()
+
+    WS.url(url).get().map { response =>
+      Ok(response.body)
+    }
+  }
+
+  def safePostWithWhitelist(value:String, amount:Int) = Action.async {
+    var url = "http://mysite.com/error"
+
+    if (value == "transfer") {
+      url = "http://mysite.com/transfer"
+    }
+
+    WS.url(url).post("amount=" + amount)
+
+    WS.url(url).post("amount=" + amount).map { response =>
       Ok(response.body)
     }
   }

--- a/scala-web-play/build.sbt
+++ b/scala-web-play/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala,SonarRunnerPlugin)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases"
 

--- a/scala-web-play/conf/routes
+++ b/scala-web-play/conf/routes
@@ -73,6 +73,8 @@ GET     /ssrf/vulnerableGet         controllers.SSRFController.vulnerableGet(val
 GET     /ssrf/vulnerablePost        controllers.SSRFController.vulnerablePost(value:String, postValue:String)
 GET     /ssrf/safeGetNotTainted     controllers.SSRFController.safeGetNotTainted()
 GET     /ssrf/safePostNotTainted    controllers.SSRFController.safePostNotTainted()
+GET     /ssrf/safeGetWithWhitelist  controllers.SSRFController.safeGetWithWhitelist(value:String, amount:Int)
+GET     /ssrf/safePostWithWhitelist controllers.SSRFController.safePostWithWhitelist(value:String, amount:Int)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/scala-web-play/project/plugins.sbt
+++ b/scala-web-play/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.8")
 
 // web plugins
 


### PR DESCRIPTION
I have updated the Scala Play sample project to use Play 2.5.x.

I have also added some code samples for Play 2.5.x WS Client SSRF.
This will allow the find-security-bugs plugin to cover SSRF vulnerabilities in both Play 2.4.x and Play 2.5.x.

This should help to fix issue find-sec-bugs/find-sec-bugs#307